### PR TITLE
Now allows the use of multiple star rating fields in the same page

### DIFF
--- a/resources/views/actions/rating-star.blade.php
+++ b/resources/views/actions/rating-star.blade.php
@@ -11,10 +11,11 @@
       @foreach ($options as $key => $value)
             @php
                 $shouldOptionBeDisabled = $isDisabled || $isOptionDisabled($key, $value);
+                $uniqueId = $id . '-' . $key; // Unique ID for each input element
             @endphp
             <input
                 @disabled($shouldOptionBeDisabled)
-                id="{{ $key }}"
+                id="{{ $uniqueId }}"
                 name="{{ $id }}"
                 type="radio"
                 value="{{ $value }}"
@@ -22,7 +23,7 @@
                 {{ $applyStateBindingModifiers('wire:model') }}="{{ $statePath }}"
                 class="star-{{ $value }}"
             />
-            <label class="star-{{ $value }}" for="{{ $key }}"></label>
+            <label class="star-{{ $value }}" for="{{ $uniqueId }}"></label>
         @endforeach
         <span></span>
     </div>


### PR DESCRIPTION
There is a bug whereby you are unable to use multiple star rating fields on the same page as they share the same id.

E.g. If you click a rating on star rating field 2, it will update on star rating field 1. 

This pull request should resolve that.