### PR TITLE
Fix view not found

### DIFF
--- a/src/Actions/RatingStarColumn.php
+++ b/src/Actions/RatingStarColumn.php
@@ -16,7 +16,7 @@ class RatingStarColumn extends Column implements Editable
     use HasToggleColors;
     use HasToggleIcons;
 
-    protected string $view = 'filament-rating-star::actions.rating-star-column';
+    protected string $view = 'filament-rating-star::columns.rating-star-column';
 
     protected function setUp(): void
     {


### PR DESCRIPTION
Currently when you use the RatingStarColumn that is in the Actions namespace, the view is not found.

Although I don't know why this class exists, because there is another RatingStarColumn in the Columns namespace.

In any case, the view that is referenced in this class currently, does not exist.