### PR TITLE
Fixing one less star on hover first and second stars

### DIFF
--- a/resources/views/actions/rating-star.blade.php
+++ b/resources/views/actions/rating-star.blade.php
@@ -116,7 +116,7 @@
   width: 40% !important;
 }
 
-.ratings .stars label.star-2:hover~span {
+.ratings .stars label.star-1:hover~span {
   width: 20% !important;
 }
 


### PR DESCRIPTION
Fixing a minor bug on the rating stars: when you put the mouse over the first and the second stars, it shows one less filled star (just a visual issue on hover).

![image](https://github.com/ibrahimBougaoua/filament-rating-star/assets/745305/82f8c3e1-7a42-4e23-baea-ed8bfa834e10)

It should fill the hovered star, as it does on the third, fourth and fifth stars:

![image](https://github.com/ibrahimBougaoua/filament-rating-star/assets/745305/44054a14-f80f-458d-a8d3-14238594288d)

Solution: the `.ratings .stars label.star-2:hover~span` CSS selector was duplicated, one of which should be `.ratings .stars label.star-1:hover~span` as there was no selector for the `star-1` CSS class.